### PR TITLE
Add listAttackers

### DIFF
--- a/src/position.ts
+++ b/src/position.ts
@@ -172,6 +172,12 @@ export interface ImmutablePosition {
    */
   isPawnDropMate(move: Move): boolean;
   /**
+   * 指定したマスに利いている駒のマス目を列挙します。
+   * @param to
+   * @param piece
+   */
+  listAttackers(to: Square): Square[];
+  /**
    * 指定したマスに利いている指定した駒のマス目を列挙します。
    * @param to
    * @param piece
@@ -347,6 +353,17 @@ export class Position {
           ignore: from,
         })
       );
+    });
+  }
+
+  /**
+   * 指定したマスに利いている駒のマス目を列挙します。
+   * @param to
+   * @param piece
+   */
+  listAttackers(to: Square): Square[] {
+    return this.board.listNonEmptySquares().filter((from) => {
+      return this.isMovable(from, to);
     });
   }
 

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -525,6 +525,49 @@ describe("position", () => {
     expect(position.hand(Color.WHITE).count(PieceType.KNIGHT)).toBe(1);
   });
 
+  it("listAttackers", () => {
+      const data = `
+後手の持駒：なし 
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| 馬 ・ ・ ・v王v金 ・ ・ ・|一
+| ・ ・ ・ ・v桂 ・ ・v角 ・|二
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|三
+| ・ ・ ・ ・v歩 ・ と ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|五
+| ・ ・ ・ ・ 歩 ・ ・ ・ ・|六
+| ・ ・ ・ 銀 ・ ・ ・ ・ ・|七
+| ・ ・ ・ ・ ・ 飛 ・ ・ ・|八
+| ・ ・ ・ ・ 王 ・ ・ ・ ・|九
++---------------------------+
+先手の持駒：なし
+後手番
+`;
+      const position = (importKIF(data) as Record).position;
+      expect(position.listAttackers(new Square(4, 4))).toStrictEqual([
+        new Square(5, 2),
+        new Square(2, 2),
+        new Square(3, 4),
+        new Square(4, 8),
+      ]);
+      expect(position.listAttackers(new Square(4, 2))).toStrictEqual([
+        new Square(5, 1),
+        new Square(4, 1),
+        new Square(4, 8),
+      ]);
+      expect(position.listAttackers(new Square(5, 5))).toStrictEqual([
+        new Square(9, 1),
+        new Square(2, 2),
+        new Square(5, 4),
+        new Square(5, 6),
+      ]);
+      expect(position.listAttackers(new Square(5, 8))).toStrictEqual([
+        new Square(6, 7),
+        new Square(4, 8),
+        new Square(5, 9),
+      ]);
+  });
+
   it("sfen", () => {
     const sfen = "l2R2s1+P/4gg1k1/p1+P2lPp1/4p1p+b1/1p3G3/3pP1nS1/PP3KSP1/R8/L4G2+b b NL4Ps2np 1";
     const position = Position.newBySFEN(sfen);


### PR DESCRIPTION
# 説明 / Description



# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `listAttackers` method to identify pieces that can attack a specified square.
  
- **Tests**
	- Added a test case for the `listAttackers` method to ensure accurate identification of attacking pieces across various board configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->