### PR TITLE
Fix resetAllBranchSelection

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -588,6 +588,7 @@ export class Record {
     this._forEach((node) => {
       node.activeBranch = node.isFirstBranch;
     });
+    this._current = (this._current.prev && this._current.prev.next) || this._current;
   }
 
   /**

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -770,6 +770,25 @@ describe("record", () => {
     ]);
   });
 
+  it("resetAllBranchSelection", () => {
+    const data = `手合割：平手
+▲７六歩 △３四歩 ▲２六歩 △８四歩 ▲２五歩 △８五歩
+変化：3手
+▲６六歩 △８四歩 ▲６八飛
+変化：4手
+△５四歩 ▲６八飛
+変化：3手
+▲７五歩 △８四歩
+`;
+    const record = importKI2(data) as Record;
+    record.goto(3);
+    record.switchBranchByIndex(2);
+    expect(record.current.branchIndex).toBe(2);
+    record.resetAllBranchSelection();
+    expect(record.current.branchIndex).toBe(0);
+    expect((record.current.move as Move).usi).toBe("2g2f");
+  });
+
   it("newByUSI/position-startpos", () => {
     // 平手100手
     const data =


### PR DESCRIPTION
# 説明 / Description

#30 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated logic for resetting branch selections in the record navigation.
	- Added a new test case to validate the functionality of resetting branch selections.

- **Bug Fixes**
	- Improved handling of current node determination after branch reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->