### PR TITLE
Add formatKIFMove

### DIFF
--- a/src/kakinoki.ts
+++ b/src/kakinoki.ts
@@ -771,9 +771,14 @@ function formatPosition(position: ImmutablePosition, options?: KIFExportOptions)
   return ret;
 }
 
-function formatMove(move: Move, prev?: Move): string {
+/**
+ * KIF 形式の指し手を出力します。
+ * @param move 対象の指し手
+ * @param prev 直前の指し手 ("同"の判定に使用)
+ */
+export function formatKIFMove(move: Move, options?: { prev?: Move; padding?: boolean }): string {
   let ret = "";
-  if (prev && move.to.equals(prev.to)) {
+  if (options?.prev && move.to.equals(options.prev.to)) {
     ret += "同\u3000";
   } else {
     ret += fileToMultiByteChar(move.to.file);
@@ -784,9 +789,11 @@ function formatMove(move: Move, prev?: Move): string {
     ret += "成";
   }
   if (move.from instanceof Square) {
-    ret += "(" + move.from.file + move.from.rank + ")" + (ret.length === 3 ? "  " : "");
+    ret += "(" + move.from.file + move.from.rank + ")";
+    ret += ret.length === 7 && options?.padding ? "  " : "";
   } else {
-    ret += "打    ";
+    ret += "打";
+    ret += options?.padding ? "    " : "";
   }
   return ret;
 }
@@ -833,7 +840,7 @@ export function exportKIF(record: ImmutableRecord, options?: KIFExportOptions): 
       ret += String(node.ply).padStart(4, " ") + " ";
       if (node.move instanceof Move) {
         const prev = node.prev?.move instanceof Move ? node.prev.move : undefined;
-        ret += formatMove(node.move, prev);
+        ret += formatKIFMove(node.move, { prev, padding: true });
       } else if (isKnownSpecialMove(node.move)) {
         const s = specialMoveToString[node.move.type];
         ret += s + " ".repeat(Math.max(12 - s.length * 2, 0));

--- a/src/tests/kakinoki.spec.ts
+++ b/src/tests/kakinoki.spec.ts
@@ -3,6 +3,7 @@ import {
   Color,
   exportKI2,
   exportKIF,
+  formatKIFMove,
   importKI2,
   importKIF,
   InitialPositionSFEN,
@@ -19,6 +20,36 @@ import {
 } from "../";
 
 describe("kakinoki", () => {
+  it("formatKIFMove", () => {
+    const testCases = [
+      {
+        move: new Move(new Square(7, 7), new Square(7, 6), false, Color.BLACK, PieceType.PAWN, null),
+        expected: "７六歩(77)",
+      },
+      {
+        move: new Move(new Square(1, 3), new Square(5, 7), true, Color.WHITE, PieceType.BISHOP, PieceType.SILVER),
+        expected: "５七角成(13)",
+      },
+      {
+        move: new Move(new Square(1, 3), new Square(5, 7), true, Color.WHITE, PieceType.BISHOP, PieceType.SILVER),
+        options: {
+          prev: new Move(new Square(6, 8), new Square(5, 7), false, Color.BLACK, PieceType.SILVER, PieceType.PROM_KNIGHT),
+        },
+        expected: "同　角成(13)",
+      },
+      {
+        move: new Move(new Square(1, 3), new Square(5, 7), true, Color.WHITE, PieceType.BISHOP, PieceType.SILVER),
+        options: {
+          prev: new Move(new Square(6, 8), new Square(6, 7), false, Color.BLACK, PieceType.SILVER, PieceType.PROM_KNIGHT),
+        },
+        expected: "５七角成(13)",
+      },
+    ];
+    for (const testCase of testCases) {
+      expect(formatKIFMove(testCase.move, testCase.options)).toBe(testCase.expected);
+    }
+  });
+
   it("import/standard", () => {
     const data = `
 # ----  Kifu for Windows V7 V7.50 棋譜ファイル  ----


### PR DESCRIPTION
# 説明 / Description

KIF 形式で指し手を個別にフォーマットできる `formatKIFMove` を公開します。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced move formatting functionality with more flexible options for KIF (Kif Intermediate Format) move representation
	- Added support for optional padding and previous move comparisons in move formatting

- **Tests**
	- Expanded test coverage for the new move formatting function to validate different move scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->