### PR TITLE
Relax sfen restrictions

### DIFF
--- a/src/hand.ts
+++ b/src/hand.ts
@@ -189,7 +189,7 @@ export class Hand {
     if (sfen === "-") {
       return true;
     }
-    return !!sfen.match(/^(?:[0-9]*[PLNSGBRplnsgbr])*$/);
+    return /^(?:[0-9]*[PLNSGBRplnsgbr])+$/.test(sfen);
   }
 
   /**
@@ -200,10 +200,10 @@ export class Hand {
     if (sfen === "-") {
       return { black: new Hand(), white: new Hand() };
     }
-    if (!sfen.match(/^(?:[0-9]*[PLNSGBRplnsgbr])*$/)) {
+    const sections = sfen.match(/([0-9]*[PLNSGBRplnsgbr])/g) as RegExpMatchArray;
+    if (!sections) {
       return null;
     }
-    const sections = sfen.match(/([0-9]*[PLNSGBRplnsgbr])/g) as RegExpMatchArray;
     const black = new Hand();
     const white = new Hand();
     for (let i = 0; i < sections.length; i += 1) {

--- a/src/hand.ts
+++ b/src/hand.ts
@@ -189,7 +189,7 @@ export class Hand {
     if (sfen === "-") {
       return true;
     }
-    return /^(?:[0-9]*[PLNSGBRplnsgbr])+$/.test(sfen);
+    return /^(?:[0-9]{0,2}[PLNSGBRplnsgbr])+$/.test(sfen);
   }
 
   /**
@@ -200,7 +200,7 @@ export class Hand {
     if (sfen === "-") {
       return { black: new Hand(), white: new Hand() };
     }
-    const sections = sfen.match(/([0-9]*[PLNSGBRplnsgbr])/g) as RegExpMatchArray;
+    const sections = sfen.match(/([0-9]{0,2}[PLNSGBRplnsgbr])/g) as RegExpMatchArray;
     if (!sections) {
       return null;
     }

--- a/src/position.ts
+++ b/src/position.ts
@@ -623,10 +623,10 @@ export class Position {
    */
   static isValidSFEN(sfen: string): boolean {
     const sections = sfen.split(" ");
-    if (sections.length === 5 && sections[0] === "sfen") {
+    if ((sections.length === 5 || sections.length === 4) && sections[0] === "sfen") {
       sections.shift();
     }
-    if (sections.length !== 4) {
+    if (sections.length !== 4 && sections.length !== 3) {
       return false;
     }
     if (!Board.isValidSFEN(sections[0])) {
@@ -638,7 +638,7 @@ export class Position {
     if (!Hand.isValidSFEN(sections[2])) {
       return false;
     }
-    if (!sections[3].match(/[0-9]+/)) {
+    if (sections.length === 4 && !/[0-9]+/.test(sections[3])) {
       return false;
     }
     return true;

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -65,6 +65,7 @@ describe("position", () => {
   });
 
   it("resetBySFEN", () => {
+    // normalized
     const testCases = [
       InitialPositionSFEN.STANDARD,
       InitialPositionSFEN.EMPTY,
@@ -86,6 +87,44 @@ describe("position", () => {
       const position = Position.newBySFEN(tc);
       expect(position).toBeInstanceOf(Position);
       expect(position?.sfen).toBe(tc);
+    }
+
+    // not normalized
+    const testCases2 = [
+      {
+        input: "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p 100",
+        output: "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p 1",
+      },
+      {
+        input: "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p",
+        output: "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p 1",
+      },
+      {
+        input: "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b PNSR2pnsr",
+        output: "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p 1",
+      },
+    ];
+    for (const tc of testCases2) {
+      const position = Position.newBySFEN(tc.input);
+      expect(position).toBeInstanceOf(Position);
+      expect(position?.sfen).toBe(tc.output);
+    }
+
+    // invalid
+    const invalids = [
+      " b - 1",
+      "x b - 1",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L  RSNPrsn2p 1",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L x RSNPrsn2p 1",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b  1",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b x 1",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p ",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p x",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L",
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b",
+    ];
+    for (const invalid of invalids) {
+      expect(Position.newBySFEN(invalid)).toBeNull();
     }
   });
 


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1115

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved validation and parsing of SFEN strings to accommodate a wider range of valid formats, enhancing user input experiences.

- **Tests**
  - Expanded test coverage for the `resetBySFEN` method, including cases for normalized and non-normalized SFEN strings, as well as invalid inputs to ensure robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->