### PR TITLE
Add ignore-scripts option

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -30,14 +30,16 @@
     }
   },
   "scripts": {
+    "audit:scripts": "node scripts/audit-scripts.mjs",
+    "install:esbuild": "npm run audit:scripts && node node_modules/esbuild/install.js",
     "build:cjs": "tsc --project tsconfig.cjs.json && node ./scripts/fix-dist-extension.mjs dist/cjs .cjs",
     "build:esm": "tsc --project tsconfig.esm.json && node ./scripts/fix-dist-extension.mjs dist/esm .mjs",
     "build": "npm run build:cjs && npm run build:esm",
     "prepare": "npm run build",
-    "test": "vitest run",
-    "bench": "vitest bench",
-    "coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui --coverage",
+    "test": "npm run install:esbuild && vitest run",
+    "bench": "npm run install:esbuild && vitest bench",
+    "coverage": "npm run install:esbuild && vitest run --coverage",
+    "test:ui": "npm run install:esbuild && vitest --ui --coverage",
     "lint": "eslint --fix --max-warnings 0 . && prettier --write .",
     "release:patch": "npm version patch",
     "release:minor": "npm version minor"

--- a/scripts/audit-scripts.mjs
+++ b/scripts/audit-scripts.mjs
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+import fs from "node:fs";
+
+function checkPackageJson(packageJsonPath) {
+  const stat = fs.statSync(packageJsonPath);
+  if (!stat.isFile()) {
+    return;
+  }
+  const packageJson = fs.readFileSync(packageJsonPath, "utf-8");
+  const { name, version, scripts } = JSON.parse(packageJson);
+
+  // All packages should have preinstall scripts
+  if (scripts?.preinstall) {
+    throw new Error(`Package ${name}@${version} has unexpected preinstall scripts`);
+  }
+
+  switch (name) {
+    // These packages have install.js scripts
+    case "esbuild":
+      if (!scripts?.postinstall) {
+        throw new Error(`Package ${name}@${version} is missing postinstall scripts`);
+      }
+      if (scripts.postinstall !== "node install.js") {
+        throw new Error(`Package ${name}@${version} has unexpected postinstall scripts`);
+      }
+      break;
+
+    // Other packages should not have postinstall scripts
+    default:
+      if (scripts?.postinstall) {
+        throw new Error(`Package ${name}@${version} has unexpected postinstall scripts`);
+      }
+      break;
+  }
+}
+
+function main() {
+  const nodeModules = fs.readdirSync("node_modules");
+  for (const module of nodeModules) {
+    if (module.startsWith(".")) {
+      continue;
+    }
+    if (module.startsWith("@")) {
+      const subModules = fs.readdirSync(`node_modules/${module}`);
+      for (const subModule of subModules) {
+        checkPackageJson(`node_modules/${module}/${subModule}/package.json`);
+      }
+      continue;
+    }
+    checkPackageJson(`node_modules/${module}/package.json`);
+  }
+}
+
+main();


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1137

`ignore-scripts` オプションを入れ、 esbuild の `install.js` に限り必要な時に個別に実行する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package management configuration to bypass running extra scripts during installation for a more secure and streamlined process.
- **New Features**
  - Introduced automation that pre-installs required dependencies before executing tests, benchmarks, and coverage commands.
  - Added an auditing mechanism to verify dependency setups, ensuring a smoother execution of development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->