### PR TITLE
Fix USI parser

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -18,6 +18,8 @@ export enum RecordFormatType {
 export function detectRecordFormat(data: string): RecordFormatType {
   // USI
   if (
+    data === "position startpos" ||
+    data === "startpos" ||
     data.startsWith("position sfen ") ||
     data.startsWith("position startpos ") ||
     data.startsWith("sfen ") ||

--- a/src/record.ts
+++ b/src/record.ts
@@ -1117,21 +1117,25 @@ export class Record {
    * @param data
    */
   static newByUSI(data: string): Record | Error {
+    const positionStartpos = "position startpos";
+    const startpos = "startpos";
     const prefixPositionStartpos = "position startpos ";
     const prefixPositionSFEN = "position sfen ";
     const prefixStartpos = "startpos ";
     const prefixSFEN = "sfen ";
     const prefixMoves = "moves ";
-    if (data.startsWith(prefixPositionStartpos)) {
-      return Record.newByUSIFromMoves(new Position(), data.slice(prefixPositionStartpos.length));
+    if (data === positionStartpos || data === startpos) {
+      return new Record();
+    } else if (data.startsWith(prefixPositionStartpos)) {
+      return Record.newByUSIFromMoves(data.slice(prefixPositionStartpos.length));
     } else if (data.startsWith(prefixPositionSFEN)) {
       return Record.newByUSIFromSFEN(data.slice(prefixPositionSFEN.length));
     } else if (data.startsWith(prefixStartpos)) {
-      return Record.newByUSIFromMoves(new Position(), data.slice(prefixStartpos.length));
+      return Record.newByUSIFromMoves(data.slice(prefixStartpos.length));
     } else if (data.startsWith(prefixSFEN)) {
       return Record.newByUSIFromSFEN(data.slice(prefixSFEN.length));
     } else if (data.startsWith(prefixMoves)) {
-      return Record.newByUSIFromMoves(new Position(), data);
+      return Record.newByUSIFromMoves(data);
     } else {
       return new InvalidUSIError(data);
     }
@@ -1147,10 +1151,10 @@ export class Record {
     if (!position) {
       return new InvalidUSIError(data);
     }
-    return Record.newByUSIFromMoves(position, sections.slice(movesIndex).join(" "));
+    return Record.newByUSIFromMoves(sections.slice(movesIndex).join(" "), position);
   }
 
-  private static newByUSIFromMoves(position: ImmutablePosition, data: string): Record | Error {
+  private static newByUSIFromMoves(data: string, position?: ImmutablePosition): Record | Error {
     const record = new Record(position);
     if (data.length === 0) {
       return record;

--- a/src/tests/detect.spec.ts
+++ b/src/tests/detect.spec.ts
@@ -2,6 +2,7 @@ import { RecordFormatType, detectRecordFormat } from "../";
 
 describe("detect", () => {
   it("usi", () => {
+    expect(detectRecordFormat(`position startpos`)).toBe(RecordFormatType.USI);
     expect(detectRecordFormat(`position startpos moves`)).toBe(RecordFormatType.USI);
     expect(
       detectRecordFormat(
@@ -13,6 +14,7 @@ describe("detect", () => {
         `sfen l2g2snl/2s1k1gb1/p1nppp1pp/2p3p2/2r6/P2P2P2/2S1PPS1P/1BG4R1/LN2KG1NL b 2P2p 1`,
       ),
     ).toBe(RecordFormatType.USI);
+    expect(detectRecordFormat(`startpos`)).toBe(RecordFormatType.USI);
     expect(detectRecordFormat(`startpos `)).toBe(RecordFormatType.USI);
     expect(detectRecordFormat(`moves `)).toBe(RecordFormatType.USI);
   });

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -812,6 +812,17 @@ describe("record", () => {
     expect((record.current.move as Move).usi).toBe("2g2f");
   });
 
+  it("newByUSI/startpos-no-moves", () => {
+    const inputs = ["position startpos", "position startpos moves", "startpos", "startpos moves"];
+    for (const input of inputs) {
+      const record = Record.newByUSI(input) as Record;
+      expect(record).toBeInstanceOf(Record);
+      expect(record.initialPosition.sfen).toBe(InitialPositionSFEN.STANDARD);
+      expect(record.length).toBe(0);
+      expect(record.position.sfen).toBe(InitialPositionSFEN.STANDARD);
+    }
+  });
+
   it("newByUSI/startpos", () => {
     // 平手100手・投了
     const inputs = [


### PR DESCRIPTION
# 説明 / Description

一部の USI 文字列がパースエラーになっていた問題を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced record input processing to support additional shorthand starting position formats.
  - Streamlined logic for creating records based on starting position inputs, improving overall handling.

- **Tests**
  - Expanded automated test coverage to ensure the new input formats are processed accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->