### PR TITLE
Fix resetAllBranchSelection

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -586,10 +586,14 @@ export class Record {
    * 全ての分岐選択を初期化して最初のノードをアクティブにします。
    */
   resetAllBranchSelection(): void {
+    for (let node = this._current; node.prev; node = node.prev) {
+      if (!node.isFirstBranch) {
+        this._current = node.prev.next as NodeImpl;
+      }
+    }
     this._forEach((node) => {
       node.activeBranch = node.isFirstBranch;
     });
-    this._current = (this._current.prev && this._current.prev.next) || this._current;
   }
 
   /**


### PR DESCRIPTION
# 説明 / Description

resetAllBranchSelection 関数を実行した時に current がメインの経路から外れてしまう問題を修正する。
親ノードで分岐があった時は合流点まで戻すようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
