### PR TITLE
Add exportBOD

### DIFF
--- a/src/kakinoki.ts
+++ b/src/kakinoki.ts
@@ -34,7 +34,7 @@ import {
 import { Square } from "./square";
 import {
   fileToMultiByteChar,
-  formatMove as formatMove2,
+  formatMove,
   numberToKanji,
   parseMoves,
   pieceTypeToStringForBoard,
@@ -741,7 +741,11 @@ function formatPosition(position: ImmutablePosition, options?: KIFExportOptions)
     case InitialPositionSFEN.HANDICAP_10PIECES:
       return "手合割：十枚落ち" + returnCode;
   }
+  return formatBOD(position, options);
+}
 
+function formatBOD(position: ImmutablePosition, options?: KIFExportOptions): string {
+  const returnCode = options?.returnCode || "\n";
   let ret = "";
   ret += "後手の持駒：" + formatHand(position.whiteHand) + returnCode;
   ret += "  ９ ８ ７ ６ ５ ４ ３ ２ １" + returnCode;
@@ -876,11 +880,11 @@ type KI2ExportOptions = {
  * @param record
  * @param options
  */
-export function exportKI2(record: ImmutableRecord, options: KI2ExportOptions): string {
+export function exportKI2(record: ImmutableRecord, options?: KI2ExportOptions): string {
   let ret = "";
   let moveCountInLine = 0;
   let lastMoveLength = 0;
-  const returnCode = options.returnCode ? options.returnCode : "\n";
+  const returnCode = options?.returnCode ? options.returnCode : "\n";
   ret += formatMetadata(record.metadata, options);
   ret += formatPosition(record.initialPosition, options);
   record.forEach((node, pos) => {
@@ -893,7 +897,7 @@ export function exportKI2(record: ImmutableRecord, options: KI2ExportOptions): s
         ret += "変化：" + node.ply + "手" + returnCode;
       }
       if (node.move instanceof Move) {
-        const str = formatMove2(pos, node.move, {
+        const str = formatMove(pos, node.move, {
           lastMove: node.prev?.move instanceof Move ? node.prev.move : undefined,
           compatible: true,
         });
@@ -955,5 +959,16 @@ export function exportKI2(record: ImmutableRecord, options: KI2ExportOptions): s
       ret += "&" + node.bookmark + returnCode;
     }
   });
+  return ret;
+}
+
+export function exportBOD(record: ImmutableRecord, options?: KIFExportOptions): string {
+  let ret = "";
+  const returnCode = options?.returnCode || "\n";
+  ret += formatBOD(record.position, options);
+  const ply = record.current.ply;
+  const lastMove = record.current.move instanceof Move ? record.current.move : undefined;
+  const lastMoveStr = lastMove ? formatKIFMove(lastMove) : "";
+  ret += `手数＝${ply}  ${lastMoveStr}  まで` + returnCode;
   return ret;
 }

--- a/src/tests/kakinoki.spec.ts
+++ b/src/tests/kakinoki.spec.ts
@@ -1,6 +1,7 @@
 import {
   anySpecialMove,
   Color,
+  exportBOD,
   exportKI2,
   exportKIF,
   formatKIFMove,
@@ -1462,5 +1463,31 @@ describe("kakinoki", () => {
       expect(record.metadata.getStandardMetadata(key)).match(/^.+テスト$/);
     }
     expect(exportKIF(record, {})).toBe(data);
+  });
+
+  it("exportBOD", () => {
+    const record = new Record();
+    record.append(record.position.createMoveByUSI("7g7f") as Move);
+    record.append(record.position.createMoveByUSI("3c3d") as Move);
+    record.append(record.position.createMoveByUSI("2g2f") as Move);
+    record.append(record.position.createMoveByUSI("2b8h+") as Move);
+    const bod = exportBOD(record);
+    expect(bod).toBe(`後手の持駒：角　
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+|v香v桂v銀v金v玉v金v銀v桂v香|一
+| ・v飛 ・ ・ ・ ・ ・ ・ ・|二
+|v歩v歩v歩v歩v歩v歩 ・v歩v歩|三
+| ・ ・ ・ ・ ・ ・v歩 ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|五
+| ・ ・ 歩 ・ ・ ・ ・ 歩 ・|六
+| 歩 歩 ・ 歩 歩 歩 歩 ・ 歩|七
+| ・v馬 ・ ・ ・ ・ ・ 飛 ・|八
+| 香 桂 銀 金 玉 金 銀 桂 香|九
++---------------------------+
+先手の持駒：なし
+先手番
+手数＝4  ８八角成(22)  まで
+`);
   });
 });


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1226

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to export a detailed board and hand representation in a new textual format, including board layout, piece positions, captured pieces, current turn, and move summary.

- **Bug Fixes**
  - Improved handling of non-standard initial positions to ensure consistent board export output.

- **Tests**
  - Introduced a new test to verify the accuracy of the board export feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->