### PR TITLE
Update csa parser

### DIFF
--- a/src/csa.ts
+++ b/src/csa.ts
@@ -93,7 +93,7 @@ const linePatterns: {
     sectionType: SectionType.HEADER,
   },
   {
-    pattern: /^P[1-9]( \* |[-+][A-Z][A-Z]){9}$/,
+    pattern: /^P[1-9]( \* ?|[-+][A-Z][A-Z]){9}$/,
     type: LineType.RANK,
     sectionType: SectionType.HEADER,
   },
@@ -194,13 +194,24 @@ function parsePosition(line: string, position: Position): void {
 
 function parseRank(line: string, position: Position): Error | undefined {
   const rank = Number(line[1]);
+  let begin = 2;
   for (let x = 0; x < 9; x += 1) {
     const file = 9 - x;
-    const begin = x * 3 + 2;
     const section = line.slice(begin, begin + 3);
+
+    // 次のマス目は通常3文字先になる。
+    // ただし " *  * " のように空きマスが続いた時にメールやHTML上で連続する空白がまとめられて " * * " となることがある。
+    // これはCSAの仕様といては正しいデータではないが、現実に存在するので配慮する。
+    // 3文字先へ進めるが、次の文字が "*" であれば1文字戻る。
+    begin += 3;
+    if (line[begin] === "*") {
+      begin -= 1;
+    }
+
     if (section[0] === " ") {
       continue;
     }
+
     const color = section[0] === "+" ? Color.BLACK : Color.WHITE;
     const pieceType = csaNameToPieceType[section.slice(1)];
     if (!pieceType) {

--- a/src/tests/csa.spec.ts
+++ b/src/tests/csa.spec.ts
@@ -970,8 +970,7 @@ $END_TIME:2024/05/04 11:05:12
 
   it("import/v3", () => {
     // http://www2.computer-shogi.org/protocol/record_v3.html より
-    const data = `
-'CSA encoding=UTF-8
+    const data = `'CSA encoding=UTF-8
 '----------棋譜ファイルの例 "example.csa"---------------
 'バージョン
 V3.0
@@ -999,13 +998,13 @@ $JISHOGI:27
 $NOTE:備考１行目\n２行目
 '平手の初期局面
 P1-KY-KE-GI-KI-OU-KI-GI-KE-KY
-P2 * -HI * * * * * -KA * 
+P2 * -HI * * * * * -KA *
 P3-FU-FU-FU-FU-FU-FU-FU-FU-FU
-P4 * * * * * * * * * 
-P5 * * * * * * * * * 
-P6 * * * * * * * * * 
+P4 * * * * * * * * *
+P5 * * * * * * * * *
+P6 * * * * * * * * *
 P7+FU+FU+FU+FU+FU+FU+FU+FU+FU
-P8 * +KA * * * * * +HI * 
+P8 * +KA * * * * * +HI *
 P9+KY+KE+GI+KI+OU+KI+GI+KE+KY
 '先手番
 +
@@ -1018,10 +1017,11 @@ P9+KY+KE+GI+KI+OU+KI+GI+KE+KY
 T6.123
 '*プログラムが読むコメント１行目
 '*プログラムが読むコメント２行目
-  %CHUDAN
-`;
+%CHUDAN
+'-------------------------------------------------`;
     const record = importCSA(data) as Record;
     expect(record).toBeInstanceOf(Record);
+    expect(record.initialPosition.sfen).toBe(InitialPositionSFEN.STANDARD);
     expect(record.metadata.getStandardMetadata(RecordMetadataKey.BLACK_NAME)).toBe("先手");
     expect(record.metadata.getStandardMetadata(RecordMetadataKey.WHITE_NAME)).toBe("後手");
     expect(record.metadata.getStandardMetadata(RecordMetadataKey.TITLE)).toBe(


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1278

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of CSA board data to correctly parse lines where spaces after asterisks are missing or collapsed, ensuring compatibility with non-standard but commonly found data formats.

* **Tests**
  * Updated and refined test cases to cover edge cases in CSA board parsing and added assertions for verifying initial position accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->