### PR TITLE
Breaking Change: Node に sfen を追加し forEach のハンドラーから Position を削除

### DIFF
--- a/src/kakinoki.ts
+++ b/src/kakinoki.ts
@@ -887,8 +887,8 @@ export function exportKI2(record: ImmutableRecord, options?: KI2ExportOptions): 
   const returnCode = options?.returnCode ? options.returnCode : "\n";
   ret += formatMetadata(record.metadata, options);
   ret += formatPosition(record.initialPosition, options);
-  record.forEach((node, pos) => {
-    if (node.ply !== 0) {
+  record.forEach((node) => {
+    if (node.prev) {
       if (!node.isFirstBranch) {
         if (!ret.endsWith(returnCode)) {
           ret += returnCode;
@@ -897,6 +897,10 @@ export function exportKI2(record: ImmutableRecord, options?: KI2ExportOptions): 
         ret += "変化：" + node.ply + "手" + returnCode;
       }
       if (node.move instanceof Move) {
+        const pos = Position.newBySFEN(node.prev.sfen);
+        if (!pos) {
+          throw new Error("Invalid SFEN");
+        }
         const str = formatMove(pos, node.move, {
           lastMove: node.prev?.move instanceof Move ? node.prev.move : undefined,
           compatible: true,

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -1,8 +1,6 @@
 import {
   Color,
   exportKIF,
-  formatMove,
-  formatSpecialMove,
   getNextColorFromUSI,
   importKI2,
   importKIF,
@@ -887,35 +885,32 @@ describe("record", () => {
 ▲７六歩△３四歩▲６六歩△３二飛
 `;
     const record = importKI2(data) as Record;
-    const results: [string, string][] = [];
-    record.forEach((node, pos) => {
-      results.push([
-        node.move instanceof Move ? formatMove(pos, node.move) : formatSpecialMove(node.move),
-        pos.getSFEN(node.ply),
-      ]);
+    const results: [string, string, number][] = [];
+    record.forEach((node) => {
+      results.push([node.displayText, node.sfen, node.ply]);
     });
     expect(results).toStrictEqual([
-      ["開始局面", "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"],
-      ["☗５六歩", "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"],
-      ["☖３四歩", "lnsgkgsnl/1r5b1/ppppppppp/9/9/4P4/PPPP1PPPP/1B5R1/LNSGKGSNL w - 2"],
-      ["☗５八飛", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B5R1/LNSGKGSNL b - 3"],
-      ["☖３二飛", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL w - 4"],
-      ["☗７六歩", "lnsgkgsnl/6rb1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL b - 5"],
-      ["☖４二銀", "lnsgkgsnl/6rb1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 6"],
-      ["中断", "lnsgkg1nl/5srb1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 7"],
-      ["☖３五歩", "lnsgkgsnl/6rb1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 6"],
-      ["☖６二銀", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL w - 4"],
-      ["☗７六歩", "ln1gkgsnl/1r1s3b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL b - 5"],
-      ["☖５四歩", "ln1gkgsnl/1r1s3b1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 6"],
-      ["☗４八玉", "ln1gkgsnl/1r1s3b1/pppp1p1pp/4p1p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 7"],
-      ["☖４二玉", "ln1gkgsnl/1r1s3b1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 6"],
-      ["☗５五歩", "ln1g1gsnl/1r1s1k1b1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 7"],
-      ["☖８四歩", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL w - 4"],
-      ["☗７六歩", "lnsgkgsnl/1r5b1/p1pppp1pp/1p4p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL b - 5"],
-      ["☗７六歩", "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"],
-      ["☖３四歩", "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 2"],
-      ["☗６六歩", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 3"],
-      ["☖３二飛", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2PP5/PP2PPPPP/1B5R1/LNSGKGSNL w - 4"],
+      ["開始局面", "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1", 0],
+      ["☗５六歩", "lnsgkgsnl/1r5b1/ppppppppp/9/9/4P4/PPPP1PPPP/1B5R1/LNSGKGSNL w - 1", 1],
+      ["☖３四歩", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B5R1/LNSGKGSNL b - 1", 2],
+      ["☗５八飛", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL w - 1", 3],
+      ["☖３二飛", "lnsgkgsnl/6rb1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL b - 1", 4],
+      ["☗７六歩", "lnsgkgsnl/6rb1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1", 5],
+      ["☖４二銀", "lnsgkg1nl/5srb1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 1", 6],
+      ["中断", "lnsgkg1nl/5srb1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 1", 7],
+      ["☖３五歩", "lnsgkgsnl/6rb1/pppppp1pp/9/6p2/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 1", 6],
+      ["☖６二銀", "ln1gkgsnl/1r1s3b1/pppppp1pp/6p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL b - 1", 4],
+      ["☗７六歩", "ln1gkgsnl/1r1s3b1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1", 5],
+      ["☖５四歩", "ln1gkgsnl/1r1s3b1/pppp1p1pp/4p1p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 1", 6],
+      ["☗４八玉", "ln1gkgsnl/1r1s3b1/pppp1p1pp/4p1p2/9/2P1P4/PP1P1PPPP/1B2RK3/LNSG1GSNL w - 1", 7],
+      ["☖４二玉", "ln1g1gsnl/1r1s1k1b1/pppppp1pp/6p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL b - 1", 6],
+      ["☗５五歩", "ln1g1gsnl/1r1s1k1b1/pppppp1pp/6p2/4P4/2P6/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1", 7],
+      ["☖８四歩", "lnsgkgsnl/1r5b1/p1pppp1pp/1p4p2/9/4P4/PPPP1PPPP/1B2R4/LNSGKGSNL b - 1", 4],
+      ["☗７六歩", "lnsgkgsnl/1r5b1/p1pppp1pp/1p4p2/9/2P1P4/PP1P1PPPP/1B2R4/LNSGKGSNL w - 1", 5],
+      ["☗７六歩", "lnsgkgsnl/1r5b1/ppppppppp/9/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL w - 1", 1],
+      ["☖３四歩", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 1", 2],
+      ["☗６六歩", "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2PP5/PP2PPPPP/1B5R1/LNSGKGSNL w - 1", 3],
+      ["☖３二飛", "lnsgkgsnl/6rb1/pppppp1pp/6p2/9/2PP5/PP2PPPPP/1B5R1/LNSGKGSNL b - 1", 4],
     ]);
   });
 


### PR DESCRIPTION
# 説明 / Description

- Node に着手後の sfen を持たせる
- Record.forEach のハンドラーの第2引数 (ImmutablePosition 型) を削除

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Each move node now explicitly tracks the SFEN string of its position, enhancing clarity and traceability of game states.

* **Refactor**
  * Simplified record traversal methods by removing position state tracking, resulting in a cleaner and more maintainable codebase.
  * Unified root node creation to use complete position data.

* **Tests**
  * Updated tests to verify the new SFEN tracking and revised node properties in move history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->