### PR TITLE
Fix isValidMove

### DIFF
--- a/src/position.ts
+++ b/src/position.ts
@@ -385,7 +385,7 @@ export class Position {
   isValidMove(move: Move): boolean {
     if (move.from instanceof Square) {
       const target = this._board.at(move.from);
-      if (!target || target.color !== this.color) {
+      if (!target || target.color !== this.color || target.type !== move.pieceType) {
         return false;
       }
       if (!this.isMovable(move.from, move.to)) {
@@ -393,6 +393,12 @@ export class Position {
       }
       const captured = this._board.at(move.to);
       if (captured && captured.color === this.color) {
+        return false;
+      }
+      if (!captured !== !move.capturedPieceType) {
+        return false;
+      }
+      if (captured && move.capturedPieceType && captured.type !== move.capturedPieceType) {
         return false;
       }
       if (move.promote) {

--- a/src/position.ts
+++ b/src/position.ts
@@ -395,7 +395,7 @@ export class Position {
       if (captured && captured.color === this.color) {
         return false;
       }
-      if (!captured !== !move.capturedPieceType) {
+      if ((captured === null) !== (move.capturedPieceType === null)) {
         return false;
       }
       if (captured && move.capturedPieceType && captured.type !== move.capturedPieceType) {

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -219,6 +219,28 @@ describe("position", () => {
       expect(position.isValidMove(drop(PieceType.BISHOP, 3, 6))).toBeFalsy();
       // 相手の駒
       expect(position.isValidMove(move(2, 6, 2, 5))).toBeFalsy();
+      // 異なる駒
+      const invalidPieceMove = move(4, 7, 4, 6);
+      invalidPieceMove.pieceType = PieceType.SILVER;
+      expect(position.isValidMove(invalidPieceMove)).toBeFalsy();
+      // 異なる取った駒
+      const invalidCapturedPieceMove = move(2, 7, 2, 6);
+      invalidCapturedPieceMove.capturedPieceType = PieceType.SILVER;
+      expect(position.isValidMove(invalidCapturedPieceMove)).toBeFalsy();
+      const invalidCapturedPieceMove2 = move(2, 7, 2, 6);
+      invalidCapturedPieceMove2.capturedPieceType = null;
+      expect(position.isValidMove(invalidCapturedPieceMove2)).toBeFalsy();
+      const invalidCapturedPieceMove3 = move(4, 7, 4, 6);
+      invalidCapturedPieceMove3.capturedPieceType = PieceType.SILVER;
+      expect(position.isValidMove(invalidCapturedPieceMove3)).toBeFalsy();
+      // 成り駒を打つ手
+      const invalidPieceDrop = drop(PieceType.BISHOP, 3, 6);
+      invalidPieceDrop.promote = true;
+      expect(position.isValidMove(invalidPieceDrop)).toBeFalsy();
+      // 相手の駒を打つ手
+      const invalidColorDrop = drop(PieceType.BISHOP, 3, 6);
+      invalidColorDrop.color = Color.WHITE;
+      expect(position.isValidMove(invalidColorDrop)).toBeFalsy();
     });
 
     it("white", () => {

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -620,6 +620,30 @@ describe("record", () => {
     expect(record1.current.ply).toBe(10);
   });
 
+  it("mergeIntoCurrentPosition:noValidMove", () => {
+    // https://github.com/sunfish-shogi/shogihome/issues/1325
+    const data = `手合割：平手
+▲５六歩    △３四歩    ▲５八飛    △６二銀    ▲７六歩    △４二金
+▲４八玉    △４一玉    ▲５五歩    △８四歩    ▲３八玉    △８五歩
+▲７七角    △３三金    ▲６八銀    △４四金    ▲５七銀    △５五金
+▲５六銀`;
+    const data2 = `手合割：平手
+▲５六歩    △３四歩    ▲５八飛    △６二銀    ▲７六歩    △４二金
+▲４八玉    △４一玉    ▲５五歩    △８四歩    ▲６八銀    △５四歩
+▲５七銀    △５五歩    ▲６六銀    △５三銀    ▲５五銀    △５四歩
+▲６六銀`;
+    const record1 = importKI2(data) as Record;
+    const record2 = importKI2(data2) as Record;
+    record1.goto(18);
+
+    const result = record1.mergeIntoCurrentPosition(record2);
+
+    expect(result.successCount).toBe(0);
+    expect(result.skipCount).toBe(19);
+    expect(exportKI2(record1, {})).toBe(data);
+    expect(record1.current.ply).toBe(18);
+  });
+
   it("repetition", () => {
     const data = `
 手合割：平手


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1325

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Strengthened move validation: the moving piece must belong to the player and match the declared piece type.
  - Enforced capture consistency: declared captured-piece type must be present and match the actual captured piece; partial or mismatched capture data now invalidates the move.
  - Promotion behavior unchanged.

- Tests
  - Added tests covering rejected moves with incorrect piece or captured-piece types.
  - Added tests for merge behavior when no valid moves, ensuring state and export remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->