### PR TITLE
Fix Record.perpetualCheck

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -730,13 +730,16 @@ export class Record implements ImmutableRecord {
       if (!this._position.doMove(move, opt)) {
         return false;
       }
-      this.incrementRepetition();
       isCheck = this.position.checked;
     }
 
     // 特殊な指し手のノードの場合は前のノードに戻る。
     if (this._current !== this.first && !(this._current.move instanceof Move)) {
       this._goBack();
+    }
+
+    if (move instanceof Move) {
+      this.incrementRepetition(this._current.ply + 1);
     }
 
     // 最終ノードの場合は単に新しいノードを追加する。
@@ -1010,13 +1013,13 @@ export class Record implements ImmutableRecord {
     return true;
   }
 
-  private incrementRepetition(): void {
+  private incrementRepetition(ply?: number): void {
     const sfen = this.position.sfen;
     if (this.repetitionCounts[sfen]) {
       this.repetitionCounts[sfen] += 1;
     } else {
       this.repetitionCounts[sfen] = 1;
-      this.repetitionStart[sfen] = this.current.ply;
+      this.repetitionStart[sfen] = ply ?? this.current.ply;
     }
   }
 
@@ -1058,7 +1061,7 @@ export class Record implements ImmutableRecord {
     let black = true;
     let white = true;
     let color = this.position.color;
-    for (let p = this.current; p.ply >= since; p = p.prev as Node) {
+    for (let p: Node | null = this.current; p && p.ply >= since; p = p.prev) {
       color = reverseColor(color);
       if (p.isCheck) {
         continue;

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -814,6 +814,163 @@ describe("record", () => {
     expect(record.perpetualCheck).toBeNull();
   });
 
+  it("perpetualCheck/initial-position", () => {
+    const data = `
+手合割：平手
+▲５八玉 △５二玉 ▲５九玉 △５一玉
+▲５八玉 △５二玉 ▲５九玉 △５一玉
+▲５八玉 △５二玉 ▲５九玉 △５一玉
+`;
+    const record = importKI2(data) as Record;
+    record.goto(11);
+    expect(record.repetition).toBeFalsy();
+    expect(record.perpetualCheck).toBeNull();
+    record.goto(12);
+    expect(record.repetition).toBeTruthy();
+    expect(record.perpetualCheck).toBeNull();
+  });
+
+  it("perpetualCheck/append/goForward/goBack", () => {
+    const testCases = [
+      {
+        initialPosition: `
+後手の持駒：なし
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|一
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|二
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|三
+| ・ ・ ・ ・ ・ ・ ・ ・v香|四
+| ・ ・ ・ ・ ・ ・ ・ ・v玉|五
+| ・ ・ ・ ・ ・ ・ ・ 飛 ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・v歩|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ 玉 ・ ・ 香 ・|九
++---------------------------+
+先手の持駒：なし
+先手番
+`,
+        pre: [],
+        oneCycle: ["2f2e", "1e1f", "2e2f", "1f1e"],
+      },
+      {
+        initialPosition: `
+後手の持駒：なし
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|一
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|二
+| ・ ・ ・ ・ ・ ・ ・ ・v香|三
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・v玉|五
+| ・ ・ ・ ・ ・ ・ ・ 飛 ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・v歩|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ 玉 ・ ・ 香 ・|九
++---------------------------+
+先手の持駒：なし
+後手番
+`,
+        pre: ["1c1d"],
+        oneCycle: ["2f2e", "1e1f", "2e2f", "1f1e"],
+      },
+      {
+        initialPosition: `
+後手の持駒：なし
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|一
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|二
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|三
+| ・ ・ ・ ・ ・ ・ ・ ・v香|四
+| ・ ・ ・ ・ ・ ・ ・ ・v玉|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・v歩|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ 玉 ・ ・ 香 ・|九
++---------------------------+
+先手の持駒：飛
+先手番
+`,
+        pre: ["R*2e"],
+        oneCycle: ["1e1f", "2e2f", "1f1e", "2f2e"],
+      },
+      {
+        initialPosition: `
+後手の持駒：なし
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|一
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|二
+| ・ ・ ・ ・ ・ ・ ・ ・v香|三
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|四
+| ・ ・ ・ ・ ・ ・ ・ ・v玉|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| ・ ・ ・ ・ ・ ・ ・ ・v歩|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ 玉 ・ ・ 香 ・|九
++---------------------------+
+先手の持駒：飛
+後手番
+`,
+        pre: ["1c1d", "R*2e"],
+        oneCycle: ["1e1f", "2e2f", "1f1e", "2f2e"],
+      },
+    ];
+    for (const testCase of testCases) {
+      const record = importKI2(testCase.initialPosition) as Record;
+      for (const usi of testCase.pre) {
+        expect(record.append(record.position.createMoveByUSI(usi) as Move)).toBeTruthy();
+      }
+      for (let i = 0; i < 3; i++) {
+        for (const usi of testCase.oneCycle) {
+          expect(record.append(record.position.createMoveByUSI(usi) as Move)).toBeTruthy();
+        }
+      }
+      expect(record.repetition).toBeTruthy();
+      expect(record.perpetualCheck).toBeTruthy();
+
+      // SpecialMove/goBack
+      expect(record.append(SpecialMoveType.RESIGN)).toBeTruthy();
+      expect(record.repetition).toBeTruthy();
+      expect(record.goBack()).toBeTruthy();
+      expect(record.repetition).toBeTruthy();
+      expect(record.perpetualCheck).toBeTruthy();
+
+      // SpecialMove/append
+      expect(record.goBack()).toBeTruthy();
+      expect(record.repetition).toBeFalsy();
+      expect(record.perpetualCheck).toBeFalsy();
+      expect(record.append(SpecialMoveType.INTERRUPT)).toBeTruthy();
+      expect(record.repetition).toBeFalsy();
+      expect(record.perpetualCheck).toBeFalsy();
+      const lastMove = testCase.oneCycle[testCase.oneCycle.length - 1];
+      expect(record.append(record.position.createMoveByUSI(lastMove) as Move)).toBeTruthy();
+      expect(record.repetition).toBeTruthy();
+      expect(record.perpetualCheck).toBeTruthy();
+
+      // goBack/goForward
+      expect(record.goBack()).toBeTruthy();
+      expect(record.repetition).toBeFalsy();
+      expect(record.perpetualCheck).toBeFalsy();
+      expect(record.goForward()).toBeTruthy();
+      expect(record.repetition).toBeTruthy();
+      expect(record.perpetualCheck).toBeTruthy();
+      for (let i = 0; i < testCase.oneCycle.length * 2; i++) {
+        expect(record.goBack()).toBeTruthy();
+        expect(record.repetition).toBeFalsy();
+        expect(record.perpetualCheck).toBeFalsy();
+      }
+      for (let i = 0; i < testCase.oneCycle.length * 2; i++) {
+        expect(record.repetition).toBeFalsy();
+        expect(record.perpetualCheck).toBeFalsy();
+        expect(record.goForward()).toBeTruthy();
+      }
+      expect(record.repetition).toBeTruthy();
+      expect(record.perpetualCheck).toBeTruthy();
+    }
+  });
+
   it("swapWithNextBranch", () => {
     const data = `
 1 ７六歩(77) ( 0:00/0:00:00)


### PR DESCRIPTION
# 説明 / Description

Issue: https://github.com/sunfish-shogi/shogihome/issues/1368

連続王手の千日手を判定する関数 `Record.perpetualCheck` における以下のバグを修正する。

発生条件:

- 条件1 - 千日手の開始地点が初手着手前 (ply=0) である
- 条件2 - 千日手の開始地点が初手着手後 (ply=1) である
- 条件3 - append 後に goBack/goForward を使用していない
- 条件4 - 最終手が王手された側の指し手である
- 条件5 - 千日手開始地点の直前が王手ではない

発生事象:

- [条件1] の場合、関数が例外を返す。
- [条件2] かつ [条件3] の場合、関数が例外を返す。
- [条件3] かつ [条件4] かつ [条件5] の場合、常に false を返す（連続王手を検出できない）。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repetition tracking so increments occur at the correct move position, preventing incorrect repetition counts across appends and branches.
  * Made perpetual-check detection null-safe during history traversal to avoid spurious perpetual-checks and handle edge cases when navigating moves.

* **Tests**
  * Added tests covering perpetual-check and repetition behavior for initial positions, appended moves, forward/back navigation, and multi-cycle repetition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->