### PR TITLE
Update formatSpecialMove

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -722,7 +722,7 @@ export class Record implements ImmutableRecord {
     const displayText =
       move instanceof Move
         ? formatMove(this.position, move, { lastMove })
-        : formatSpecialMove(move);
+        : formatSpecialMove(move, this.current.nextColor);
 
     // 局面を動かす。
     let isCheck = false;

--- a/src/tests/text.spec.ts
+++ b/src/tests/text.spec.ts
@@ -20,6 +20,20 @@ describe("text", () => {
   it("formatSpecialMove", () => {
     expect(formatSpecialMove(SpecialMoveType.RESIGN)).toBe("投了");
     expect(formatSpecialMove(specialMove(SpecialMoveType.TIMEOUT))).toBe("切れ負け");
+    expect(formatSpecialMove(specialMove(SpecialMoveType.FOUL_LOSE))).toBe("反則負け");
+    expect(formatSpecialMove(specialMove(SpecialMoveType.FOUL_WIN))).toBe("反則勝ち");
+    expect(formatSpecialMove(specialMove(SpecialMoveType.FOUL_LOSE), Color.BLACK)).toBe(
+      "先手の反則負け",
+    );
+    expect(formatSpecialMove(specialMove(SpecialMoveType.FOUL_LOSE), Color.WHITE)).toBe(
+      "後手の反則負け",
+    );
+    expect(formatSpecialMove(specialMove(SpecialMoveType.FOUL_WIN), Color.BLACK)).toBe(
+      "後手の反則負け",
+    );
+    expect(formatSpecialMove(specialMove(SpecialMoveType.FOUL_WIN), Color.WHITE)).toBe(
+      "先手の反則負け",
+    );
     expect(formatSpecialMove(anySpecialMove("休憩"))).toBe("休憩");
   });
 

--- a/src/text.ts
+++ b/src/text.ts
@@ -186,14 +186,19 @@ const specialMoveToDisplayStringMap: {
  * 特殊な指し手の表示用の文字列を返します。
  * @param move
  */
-export function formatSpecialMove(move: SpecialMove | SpecialMoveType): string {
-  if (typeof move === "string") {
-    return specialMoveToDisplayStringMap[move];
+export function formatSpecialMove(move: SpecialMove | SpecialMoveType, color?: Color): string {
+  if (typeof move !== "string" && !isKnownSpecialMove(move)) {
+    return move.name;
   }
-  if (isKnownSpecialMove(move)) {
-    return specialMoveToDisplayStringMap[move.type];
+  const moveType = typeof move === "string" ? move : move.type;
+  if (color !== undefined) {
+    if (moveType === SpecialMoveType.FOUL_LOSE) {
+      return color === Color.BLACK ? "先手の反則負け" : "後手の反則負け";
+    } else if (moveType === SpecialMoveType.FOUL_WIN) {
+      return color === Color.BLACK ? "後手の反則負け" : "先手の反則負け";
+    }
   }
-  return move.name;
+  return specialMoveToDisplayStringMap[moveType];
 }
 
 /**


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1371

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Special moves and game-ending actions now include contextual color-aware display, making record entries clearer (e.g., color-specific phrasing for foul outcomes).
* **Tests**
  * Added tests verifying color-sensitive formatting for fouls and preserved coverage for resign/timeouts/other special moves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->