### PR TITLE
Update getUSI

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -364,7 +364,17 @@ export type USIFormatOptions = {
   startpos?: boolean;
   /** 投了 "resign" を出力に含めるかどうかを表します。デフォルトは false です。 */
   resign?: boolean;
-  /** 全ての指し手を含めるかどうかを指定します。デフォルトは false です。 */
+  /** 千日手 "rep_draw" を出力に含めるかどうかを表します。デフォルトは false です。 */
+  repDraw?: boolean;
+  /** 引き分け "draw" を出力に含めるかどうかを表します。デフォルトは false です。 */
+  draw?: boolean;
+  /** 時間切れ "timeout" を出力に含めるかどうかを表します。デフォルトは false です。 */
+  timeout?: boolean;
+  /** 中断 "break" を出力に含めるかどうかを表します。デフォルトは false です。 */
+  break?: boolean;
+  /** 宣言勝ち "win" を出力に含めるかどうかを表します。デフォルトは false です。 */
+  win?: boolean;
+  /** 全ての指し手を含めるかどうかを指定します。 false の場合は現在の局面までの指し手のみが含まれます。デフォルトは false です。 */
   allMoves?: boolean;
 };
 
@@ -1099,6 +1109,16 @@ export class Record implements ImmutableRecord {
         moves.push(p.move.usi);
       } else if (opts?.resign && p.move.type === SpecialMoveType.RESIGN) {
         moves.push("resign");
+      } else if (opts?.repDraw && p.move.type === SpecialMoveType.REPETITION_DRAW) {
+        moves.push("rep_draw");
+      } else if (opts?.draw && p.move.type === SpecialMoveType.DRAW) {
+        moves.push("draw");
+      } else if (opts?.timeout && p.move.type === SpecialMoveType.TIMEOUT) {
+        moves.push("timeout");
+      } else if (opts?.break && p.move.type === SpecialMoveType.INTERRUPT) {
+        moves.push("break");
+      } else if (opts?.win && p.move.type === SpecialMoveType.ENTERING_OF_KING) {
+        moves.push("win");
       }
       if (!p.next || (!opts?.allMoves && p === this.current)) {
         break;

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -107,13 +107,77 @@ describe("record", () => {
         allMoves: true,
       }),
     ).toBe("position startpos moves 2g2f 8c8d 7g7f 8d8e");
-    expect(
-      record.getUSI({
-        startpos: true,
-        resign: true,
-        allMoves: true,
-      }),
-    ).toBe("position startpos moves 2g2f 8c8d 7g7f 8d8e resign");
+  });
+
+  it("getUSI/specialMoves", () => {
+    const precedingUSI = "position startpos moves 7g7f 3c3d 2g2f 8c8d";
+    const testCases = [
+      {
+        specialMove: SpecialMoveType.RESIGN,
+        opts: {},
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      },
+      {
+        specialMove: SpecialMoveType.RESIGN,
+        opts: { resign: true },
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d resign",
+      },
+      {
+        specialMove: SpecialMoveType.REPETITION_DRAW,
+        opts: {},
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      },
+      {
+        specialMove: SpecialMoveType.REPETITION_DRAW,
+        opts: { repDraw: true },
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d rep_draw",
+      },
+      {
+        specialMove: SpecialMoveType.DRAW,
+        opts: {},
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      },
+      {
+        specialMove: SpecialMoveType.DRAW,
+        opts: { draw: true },
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d draw",
+      },
+      {
+        specialMove: SpecialMoveType.TIMEOUT,
+        opts: {},
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      },
+      {
+        specialMove: SpecialMoveType.TIMEOUT,
+        opts: { timeout: true },
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d timeout",
+      },
+      {
+        specialMove: SpecialMoveType.INTERRUPT,
+        opts: {},
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      },
+      {
+        specialMove: SpecialMoveType.INTERRUPT,
+        opts: { break: true },
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d break",
+      },
+      {
+        specialMove: SpecialMoveType.ENTERING_OF_KING,
+        opts: {},
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d",
+      },
+      {
+        specialMove: SpecialMoveType.ENTERING_OF_KING,
+        opts: { win: true },
+        usi: "position startpos moves 7g7f 3c3d 2g2f 8c8d win",
+      },
+    ];
+    for (const testCase of testCases) {
+      const record = Record.newByUSI(precedingUSI) as Record;
+      record.append(testCase.specialMove);
+      expect(record.getUSI(testCase.opts)).toBe(testCase.usi);
+    }
   });
 
   it("usen/single", () => {


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1275

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended USI format with new optional flags to control how special game moves are represented: repetition draw, draw, timeout, break, and win conditions
  * Each option can be independently enabled to include the corresponding special move indicator in USI output

* **Tests**
  * Added comprehensive tests verifying USI generation with all special move types and option combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->