### PR TITLE
Use absolute CONTRIBUTING.md links in issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/不具合報告---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/不具合報告---bug-report.md
@@ -9,7 +9,7 @@ assignees: sunfish-shogi
 
 ## Checklist
 
-- [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+- [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
 - [ ] do not remove following sections
 
 ## 説明 / Description

--- a/.github/ISSUE_TEMPLATE/提案---suggestion.md
+++ b/.github/ISSUE_TEMPLATE/提案---suggestion.md
@@ -9,7 +9,7 @@ assignees: sunfish-shogi
 
 ## Checklist
 
-- [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+- [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
 - [ ] do not remove following sections
 
 ## 説明 /  Description

--- a/.github/ISSUE_TEMPLATE/質問---question.md
+++ b/.github/ISSUE_TEMPLATE/質問---question.md
@@ -9,7 +9,6 @@ assignees: sunfish-shogi
 
 ## Checklist
 
-- [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+- [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
 
 ## 質問 / Question
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,6 @@
   - [ ] `npm run lint` was applied without warnings
   - [ ] `console.log` not included (except script file)
 - MUST (for Outside Contributor)
-  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/shogihome/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
+  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
 - RECOMMENDED (it depends on what you change)
   - [ ] unit test added/updated


### PR DESCRIPTION
### Motivation
- Relative links to the contribution guide do not resolve correctly in GitHub issue and PR templates.
- Ensure contributors are directed to the canonical contribution guide at `https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md`.
- Keep templates consistent and reduce confusion for outside contributors.

### Description
- Updated `.github/ISSUE_TEMPLATE/不具合報告---bug-report.md` to use the absolute `CONTRIBUTING.md` URL.
- Updated `.github/ISSUE_TEMPLATE/質問---question.md` to use the absolute `CONTRIBUTING.md` URL.
- Updated `.github/ISSUE_TEMPLATE/提案---suggestion.md` to use the absolute `CONTRIBUTING.md` URL.
- Updated `.github/PULL_REQUEST_TEMPLATE.md` to use the absolute `CONTRIBUTING.md` URL in the contributor checklist.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6a258abc8321857de45da00b5ee6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub issue and pull request templates to reference the contribution guidelines document, providing consistent guidance for all contributors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->