### PR TITLE
Guard against missing source piece and stop applying invalid moves in PV/JKF generation

### DIFF
--- a/src/jkf.ts
+++ b/src/jkf.ts
@@ -482,7 +482,9 @@ function buildJKFMoves(
     }
     moves.push(entry);
     if (node.move instanceof Move) {
-      position.doMove(node.move, { ignoreValidation: true });
+      if (!position.doMove(node.move, { ignoreValidation: true })) {
+        break;
+      }
     }
   }
   return moves;

--- a/src/position.ts
+++ b/src/position.ts
@@ -465,7 +465,10 @@ export class Position {
       return false;
     }
     if (move.from instanceof Square) {
-      const target = this._board.at(move.from) as Piece;
+      const target = this._board.at(move.from);
+      if (!target) {
+        return false;
+      }
       const captured = this._board.at(move.to);
       this._board.remove(move.from);
       this._board.set(move.to, move.promote ? target.promoted() : target);

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -162,6 +162,24 @@ describe("position", () => {
     expect(position.board.at(new Square(2, 6))).toStrictEqual(
       new Piece(Color.BLACK, PieceType.ROOK),
     );
+    const invalidPromoteMove = new Move(
+      new Square(1, 4),
+      new Square(1, 3),
+      true,
+      position.color,
+      PieceType.PAWN,
+      null,
+    );
+    expect(() =>
+      position.doMove(invalidPromoteMove, {
+        ignoreValidation: true,
+      }),
+    ).not.toThrow();
+    expect(
+      position.doMove(invalidPromoteMove, {
+        ignoreValidation: true,
+      }),
+    ).toBeFalsy();
   });
 
   describe("isValidMove", () => {

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -162,21 +162,10 @@ describe("position", () => {
     expect(position.board.at(new Square(2, 6))).toStrictEqual(
       new Piece(Color.BLACK, PieceType.ROOK),
     );
-    const invalidPromoteMove = new Move(
-      new Square(1, 4),
-      new Square(1, 3),
-      true,
-      position.color,
-      PieceType.PAWN,
-      null,
-    );
-    expect(() =>
-      position.doMove(invalidPromoteMove, {
-        ignoreValidation: true,
-      }),
-    ).not.toThrow();
+    // ignoreValidation でも移動元の駒が存在しない場合は false を返す
+    move = new Move(new Square(1, 4), new Square(1, 3), true, position.color, PieceType.PAWN, null);
     expect(
-      position.doMove(invalidPromoteMove, {
+      position.doMove(move, {
         ignoreValidation: true,
       }),
     ).toBeFalsy();

--- a/src/tests/text.spec.ts
+++ b/src/tests/text.spec.ts
@@ -142,6 +142,17 @@ describe("text", () => {
     expect(formatPV(position, pv)).toBe("▲７六歩△３四歩▲５八金右△８八角成▲同　銀");
   });
 
+  it("formatPV/invalid move", () => {
+    const position = new Position();
+    const pv = [
+      new Move(new Square(7, 7), new Square(7, 6), false, Color.BLACK, PieceType.PAWN, null),
+      new Move(new Square(1, 4), new Square(1, 3), true, Color.WHITE, PieceType.PAWN, null),
+      new Move(new Square(3, 3), new Square(3, 4), false, Color.WHITE, PieceType.PAWN, null),
+    ];
+    expect(() => formatPV(position, pv)).not.toThrow();
+    expect(formatPV(position, pv)).toBe("▲７六歩△１三歩成");
+  });
+
   it("parsePV", () => {
     const record = importKIF(`
 後手の持駒：

--- a/src/text.ts
+++ b/src/text.ts
@@ -348,7 +348,9 @@ export function formatPV(position: ImmutablePosition, pv: Move[]): string {
       lastMove,
       compatible: true,
     })}`;
-    p.doMove(move, { ignoreValidation: true });
+    if (!p.doMove(move, { ignoreValidation: true })) {
+      break;
+    }
     lastMove = move;
   }
   return ret;


### PR DESCRIPTION
#120 

### Motivation

- Prevent malformed or invalid moves from corrupting a cloned `Position` when formatting PVs or exporting JKF and to avoid runtime errors when a move references a missing source square.  

### Description

- Add a guard in `Position.doMove` to return `false` when the source square is empty instead of assuming a `Piece` is present (`src/position.ts`).  
- Stop iterating when applying moves if `doMove` returns `false` in `formatPV` (`src/text.ts`) and in the JKF move builder (`src/jkf.ts`).  
- Add tests that cover an invalid promotion move and an invalid move in a PV: `formatPV/invalid move` in `src/tests/text.spec.ts` and an `invalidPromoteMove` case in `src/tests/position.spec.ts`.

### Testing

- Ran the unit test suite including the updated `src/tests/position.spec.ts` and `src/tests/text.spec.ts` tests, and the test run completed successfully.  
- The new cases verify that `doMove` does not throw for ignored-validation calls and that `formatPV` stops on an invalid move and returns the expected truncated PV string.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e09de48c832199c6a9b2fae7146f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Move processing now stops when a move cannot be applied, preventing invalid state propagation and incorrect subsequent entries.
  * Move application returns a falsy result for moves with missing source pieces, avoiding unexpected success under ignored validation.

* **Tests**
  * Expanded tests to cover invalid-move scenarios, asserting non-throwing behavior, false return for unappliable moves, and expected formatted output for truncated PVs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->