### PR TITLE
Fix ILLEGAL_ACTION bug

### DIFF
--- a/src/csa.ts
+++ b/src/csa.ts
@@ -9,7 +9,7 @@ import {
   InvalidTurnError,
   PieceNotExistsError,
 } from "./errors";
-import { Color, reverseColor } from "./color";
+import { Color } from "./color";
 import { ImmutableHand } from "./hand";
 import { anySpecialMove, Move, specialMove, SpecialMove, SpecialMoveType } from "./move";
 import { Piece, PieceType, promotedPieceType } from "./piece";
@@ -318,11 +318,11 @@ export function getSpecialMoveByName(name: string, color: Color): SpecialMove {
       return specialMove(SpecialMoveType.FOUL_LOSE);
     case "+ILLEGAL_ACTION":
       return specialMove(
-        color == Color.BLACK ? SpecialMoveType.FOUL_WIN : SpecialMoveType.FOUL_LOSE,
+        color == Color.BLACK ? SpecialMoveType.FOUL_LOSE : SpecialMoveType.FOUL_WIN,
       );
     case "-ILLEGAL_ACTION":
       return specialMove(
-        color == Color.WHITE ? SpecialMoveType.FOUL_WIN : SpecialMoveType.FOUL_LOSE,
+        color == Color.WHITE ? SpecialMoveType.FOUL_LOSE : SpecialMoveType.FOUL_WIN,
       );
     case "KACHI":
       return specialMove(SpecialMoveType.ENTERING_OF_KING);
@@ -631,7 +631,7 @@ export function getCSASpecialMoveName(move: SpecialMove, color: Color): string |
     case SpecialMoveType.FOUL_LOSE:
       return "ILLEGAL_MOVE";
     case SpecialMoveType.FOUL_WIN:
-      return color == Color.BLACK ? "+ILLEGAL_ACTION" : "-ILLEGAL_ACTION";
+      return color == Color.BLACK ? "-ILLEGAL_ACTION" : "+ILLEGAL_ACTION";
     case SpecialMoveType.ENTERING_OF_KING:
       return "KACHI";
   }
@@ -675,7 +675,7 @@ export function exportCSA(record: ImmutableRecord, options?: CSAExportOptions): 
       if (node.move instanceof Move) {
         move = formatCSAMove(node.move);
       } else {
-        const name = getCSASpecialMoveName(node.move, reverseColor(node.nextColor));
+        const name = getCSASpecialMoveName(node.move, node.nextColor);
         if (name) {
           move = "%" + name;
         }

--- a/src/jkf.ts
+++ b/src/jkf.ts
@@ -1,7 +1,7 @@
 // JSON Kifu Format (.jkf .json)
 // See https://github.com/na2hiro/Kifu-for-JS/blob/master/packages/json-kifu-format/README.md
 
-import { Color, reverseColor } from "./color";
+import { Color } from "./color";
 import { getSpecialMoveByName, getCSASpecialMoveName } from "./csa";
 import { kakinokiToMetadataKey, metadataKeyToKakinoki } from "./kakinoki";
 import { Move } from "./move";
@@ -462,7 +462,7 @@ function buildJKFMoves(
         entry.move.relative = relative;
       }
     } else {
-      const command = getCSASpecialMoveName(node.move, reverseColor(node.nextColor));
+      const command = getCSASpecialMoveName(node.move, node.nextColor);
       if (!command) {
         break;
       }

--- a/src/tests/csa.spec.ts
+++ b/src/tests/csa.spec.ts
@@ -172,7 +172,7 @@ PI
     expect(record.current.move).toStrictEqual(specialMove(SpecialMoveType.FOUL_LOSE));
   });
 
-  it("import/black_illegal_action", () => {
+  it("import/white_illegal_action", () => {
     const data = `V2.2
 PI
 +
@@ -1208,6 +1208,20 @@ T0
   it("export/black_illegal_action", () => {
     const record = new Record();
     record.append(record.position.createMoveByUSI("7g7f") as Move);
+    record.append(SpecialMoveType.FOUL_WIN);
+    expect(exportCSA(record)).toBe(`V2.2
+PI
++
++7776FU
+T0
+%+ILLEGAL_ACTION
+T0
+`);
+  });
+
+  it("export/white_illegal_action", () => {
+    const record = new Record();
+    record.append(record.position.createMoveByUSI("7g7f") as Move);
     record.append(record.position.createMoveByUSI("3c3d") as Move);
     record.append(SpecialMoveType.FOUL_WIN);
     expect(exportCSA(record)).toBe(`V2.2
@@ -1218,20 +1232,6 @@ T0
 -3334FU
 T0
 %-ILLEGAL_ACTION
-T0
-`);
-  });
-
-  it("export/white_illegal_action", () => {
-    const record = new Record();
-    record.append(record.position.createMoveByUSI("7g7f") as Move);
-    record.append(SpecialMoveType.FOUL_WIN);
-    expect(exportCSA(record)).toBe(`V2.2
-PI
-+
-+7776FU
-T0
-%+ILLEGAL_ACTION
 T0
 `);
   });

--- a/src/tests/csa.spec.ts
+++ b/src/tests/csa.spec.ts
@@ -158,6 +158,34 @@ PI
     expect(record.current.move).toStrictEqual(specialMove(SpecialMoveType.FOUL_LOSE));
   });
 
+  it("import/black_illegal_action", () => {
+    const data = `V2.2
+PI
++
++7776FU
+-3334FU
+%+ILLEGAL_ACTION
+`;
+    const record = importCSA(data) as Record;
+    expect(record).toBeInstanceOf(Record);
+    record.goto(3);
+    expect(record.current.move).toStrictEqual(specialMove(SpecialMoveType.FOUL_LOSE));
+  });
+
+  it("import/black_illegal_action", () => {
+    const data = `V2.2
+PI
++
++7776FU
+-3334FU
+%-ILLEGAL_ACTION
+`;
+    const record = importCSA(data) as Record;
+    expect(record).toBeInstanceOf(Record);
+    record.goto(3);
+    expect(record.current.move).toStrictEqual(specialMove(SpecialMoveType.FOUL_WIN));
+  });
+
   it("import/jishogi", () => {
     const data = `V2.2
 PI
@@ -1173,6 +1201,37 @@ T0
 -3334FU
 T0
 %ILLEGAL_MOVE
+T0
+`);
+  });
+
+  it("export/black_illegal_action", () => {
+    const record = new Record();
+    record.append(record.position.createMoveByUSI("7g7f") as Move);
+    record.append(record.position.createMoveByUSI("3c3d") as Move);
+    record.append(SpecialMoveType.FOUL_WIN);
+    expect(exportCSA(record)).toBe(`V2.2
+PI
++
++7776FU
+T0
+-3334FU
+T0
+%-ILLEGAL_ACTION
+T0
+`);
+  });
+
+  it("export/white_illegal_action", () => {
+    const record = new Record();
+    record.append(record.position.createMoveByUSI("7g7f") as Move);
+    record.append(SpecialMoveType.FOUL_WIN);
+    expect(exportCSA(record)).toBe(`V2.2
+PI
++
++7776FU
+T0
+%+ILLEGAL_ACTION
 T0
 `);
   });


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1582

ILLEGAL_ACTION の実装が手番に対して逆になっていたのを修正する。

> %+ILLEGAL_ACTION 先手（下手）の反則行為により、後手（上手）の勝ち
> %-ILLEGAL_ACTION 後手（上手）の反則行為により、先手（下手）の勝ち

> ※%+ILLEGAL_ACTION,%-ILLEGAL_ACTIONは、手番側の勝ちを表現できる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced support for illegal-action moves in CSA format import and export workflows.

* **Tests**
  * Added comprehensive test coverage for illegal-action move handling across import and export scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->