### PR TITLE
Add workaround for shogidb2

### DIFF
--- a/src/tests/kakinoki.spec.ts
+++ b/src/tests/kakinoki.spec.ts
@@ -1158,6 +1158,33 @@ describe("kakinoki", () => {
     );
   });
 
+  it("import/ki2/shogidb2", () => {
+    // Shogi DB2 の KI2 形式は「投了」や「千日手」を指し手と同列で表記している。
+    const testCases = [
+      {
+        data: "▲２六歩 △３四歩 ▲７六歩 △５四歩 ▲４八銀 △５二飛 ▲６八玉 △５五歩 ▲７八玉 △投了\nまで9手で先手の勝ち",
+        moveCount: 11,
+      },
+      {
+        data: "▲２六歩 △３四歩 ▲７六歩 △５四歩 ▲４八銀 △５二飛 ▲６八玉 △５五歩 △投了\nまで8手で後手の勝ち",
+        moveCount: 10,
+      },
+      {
+        data: "▲２六歩 △３四歩 ▲７六歩 △５四歩 ▲４八銀 △５二飛 ▲６八玉 △５五歩 ▲７八玉 △千日手\nまで9手で千日手",
+        moveCount: 11,
+      },
+      {
+        data: "▲２六歩 △３四歩 ▲７六歩 △５四歩 ▲４八銀 △５二飛 ▲６八玉 △５五歩 △千日手\nまで8手で千日手",
+        moveCount: 10,
+      },
+    ];
+    for (const { data, moveCount } of testCases) {
+      const record = importKI2(data) as Record;
+      expect(record).toBeInstanceOf(Record);
+      expect(record.moves).toHaveLength(moveCount);
+    }
+  });
+
   it("export/standard", () => {
     const record = new Record();
     record.metadata.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "藤井");

--- a/src/text.ts
+++ b/src/text.ts
@@ -359,6 +359,24 @@ export function formatPV(position: ImmutablePosition, pv: Move[]): string {
 const moveRegExp =
   /^[▲△▼▽☗☖]?([１２３４５６７８９一二三四五六七八九1-9]{2}|同)(王|玉|飛|龍|竜|角|馬|金|銀|成銀|全|桂|成桂|圭|香|成香|杏|歩|と)(左|直|右|)(引|寄|上|)(成|不成|打|)(\([1-9][1-9]\)|)/;
 
+// 指し手の読み込み時に無視する文言
+// NOTE: Shogi DB2 の KI2 形式が「投了」や「千日手」を指し手と同列で表記している。
+const ignoredKI2MoveNames = new Set([
+  "中断",
+  "投了",
+  "持将棋",
+  "千日手",
+  "詰み",
+  "詰",
+  "不詰",
+  "切れ負け",
+  "反則勝ち",
+  "反則負け",
+  "入玉勝ち",
+  "不戦勝",
+  "不戦敗",
+]);
+
 export function parsePV(position: ImmutablePosition, text: string): Move[] {
   return parseMoves(position, text)[0];
 }
@@ -399,6 +417,9 @@ export function parseMoves(
   const p = position.clone();
   const pv: Move[] = [];
   for (const section of sections) {
+    if (ignoredKI2MoveNames.has(section.substring(1))) {
+      break;
+    }
     const result = moveRegExp.exec(section);
     if (!result) {
       return [pv, new InvalidMoveError(section)];


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1603

Shogi DB2 が出力する KI2 への対策

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved KI2 format parsing to properly handle ShogiDB2-style game records where end-of-game results (such as 投了, 千日手, and other game-ending markers) appear inline with move notation. This enhancement expands compatibility with diverse game data sources and reduces import errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sunfish-shogi/tsshogi/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->