### PR TITLE
Fix jishogi judgement bug

### DIFF
--- a/src/position.ts
+++ b/src/position.ts
@@ -912,18 +912,20 @@ export function judgeJishogiDeclaration(
   // 24 点法
   if (rule === JishogiDeclarationRule.GENERAL24) {
     return point >= 31
-      ? JishogiDeclarationResult.WIN
+      ? JishogiDeclarationResult.WIN // 31 点以上で勝ち
       : point >= 24
-        ? JishogiDeclarationResult.DRAW
-        : JishogiDeclarationResult.LOSE;
+        ? JishogiDeclarationResult.DRAW // 24 点以上31点未満で引き分け
+        : JishogiDeclarationResult.LOSE; // 24 点未満で負け
   }
 
   // 27 点法
   if (color === Color.BLACK) {
     // 先手は 28 点以上で勝ち
-    return point >= 28 ? JishogiDeclarationResult.WIN : JishogiDeclarationResult.DRAW;
+    // 足りなければ負け
+    return point >= 28 ? JishogiDeclarationResult.WIN : JishogiDeclarationResult.LOSE;
   } else {
     // 後手は 27 点以上で勝ち
-    return point >= 27 ? JishogiDeclarationResult.WIN : JishogiDeclarationResult.DRAW;
+    // 足りなければ負け
+    return point >= 27 ? JishogiDeclarationResult.WIN : JishogiDeclarationResult.LOSE;
   }
 }

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -851,7 +851,7 @@ describe("position", () => {
         black24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
         black27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
         white24: JishogiDeclarationResult.DRAW, // お互い24点以上なので引き分け
-        white27: JishogiDeclarationResult.WIN, // 敵陣の駒が足りないので負け
+        white27: JishogiDeclarationResult.WIN, // 27点に達しているので勝ち
       },
       {
         title: "gote_11pieces_26points",

--- a/src/tests/position.spec.ts
+++ b/src/tests/position.spec.ts
@@ -810,6 +810,91 @@ describe("position", () => {
         white24: JishogiDeclarationResult.LOSE,
         white27: JishogiDeclarationResult.LOSE,
       },
+      {
+        // https://www.youtube.com/live/mRVb8QlZat4?si=qpN7-KOdVOSei2MX&t=5831
+        title: "shitate_11pieces_27points",
+        sfen: "5+B+P2/K+P1+P+R+P3/+P+P+NPP4/7g1/6gg1/5+n1s1/3+p+p4/1+p3+n1k1/9 b G2SNL3Psl4p 1",
+        blackInvading: 11,
+        whiteInvading: 4,
+        blackTotalPoint: 27,
+        whiteTotalPoint: 27,
+        blackPoint: 27,
+        whitePoint: 22,
+        black24: JishogiDeclarationResult.DRAW, // お互い24点以上なので引き分け
+        black27: JishogiDeclarationResult.LOSE, // 28点に達していないので負け
+        white24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        white27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+      },
+      {
+        title: "uwate_4pieces_27points",
+        sfen: "5+B+P2/K+P1+P+R+P3/+P+P+NPP4/7g1/6gg1/5+n1s1/3+p+p4/1+p3+n1k1/9 w G2SNL3Psl4p 1",
+        blackInvading: 11,
+        whiteInvading: 4,
+        blackTotalPoint: 27,
+        whiteTotalPoint: 27,
+        blackPoint: 27,
+        whitePoint: 22,
+        black24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        black27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        white24: JishogiDeclarationResult.LOSE, // 敵陣の駒が足りないので負け
+        white27: JishogiDeclarationResult.LOSE, // 敵陣の駒が足りないので負け
+      },
+      {
+        title: "uwate_10pieces_27points",
+        sfen: "5+B+P2/K+P1+P+R+P3/+P+P+NPP4/9/9/9/2p+p+pgsg1/1+p1+n1+n1kg/9 w G2SNL3Psl3p 1",
+        blackInvading: 11,
+        whiteInvading: 10,
+        blackTotalPoint: 27,
+        whiteTotalPoint: 27,
+        blackPoint: 27,
+        whitePoint: 27,
+        black24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        black27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        white24: JishogiDeclarationResult.DRAW, // お互い24点以上なので引き分け
+        white27: JishogiDeclarationResult.WIN, // 敵陣の駒が足りないので負け
+      },
+      {
+        title: "gote_11pieces_26points",
+        sfen: "5+B+P2/K+P+L+P+R+P3/+P+P+N1P4/9/9/9/2p+p+pgsg1/1+p1+n+b+n1kg/9 w G2SNL4Prs2l3p 1",
+        blackInvading: 11,
+        whiteInvading: 11,
+        blackTotalPoint: 28,
+        whiteTotalPoint: 26,
+        blackPoint: 28,
+        whitePoint: 26,
+        black24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        black27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        white24: JishogiDeclarationResult.DRAW, // お互い24点以上なので引き分け
+        white27: JishogiDeclarationResult.LOSE, // 27点に達していないので負け
+      },
+      {
+        title: "sente_11pieces_23points",
+        sfen: "5+B+P2/K+P+L+P+R+P3/+P+P+N1P4/1LSS1P3/3P5/9/2p+p+pgsg1/1+p1+n+b+n1kg/9 b GN2Prs2l3p 1",
+        blackInvading: 11,
+        whiteInvading: 11,
+        blackTotalPoint: 28,
+        whiteTotalPoint: 26,
+        blackPoint: 23,
+        whitePoint: 26,
+        black24: JishogiDeclarationResult.LOSE, // 24点に達していないので負け
+        black27: JishogiDeclarationResult.LOSE, // 27点に達していないので負け
+        white24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        white27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+      },
+      {
+        title: "sente_11pieces_24points",
+        sfen: "5+B+P2/K+P+L+P+R+P3/+P+P+N1P4/1LSS5/3P5/9/2p+p+pgsg1/1+p1+n+b+n1kg/9 b GN3Prs2l3p 1",
+        blackInvading: 11,
+        whiteInvading: 11,
+        blackTotalPoint: 28,
+        whiteTotalPoint: 26,
+        blackPoint: 24,
+        whitePoint: 26,
+        black24: JishogiDeclarationResult.DRAW, // お互い24点以上なので引き分け
+        black27: JishogiDeclarationResult.LOSE, // 27点に達していないので負け
+        white24: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+        white27: JishogiDeclarationResult.LOSE, // 手番ではないので負け
+      },
     ];
     for (const tc of testCases) {
       it(tc.title, () => {


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/shogihome/issues/1627

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [CONTRIBUTING.md](https://github.com/sunfish-shogi/tsshogi/blob/main/CONTRIBUTING.md)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected outcome determination for the 27-point scoring rule: when the score threshold is not reached, the result is now a loss for both sides.

* **Tests**
  * Added comprehensive SFEN-based test coverage covering multiple 24‑point and 27‑point scenarios to validate declaration outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->